### PR TITLE
fix(kaspax): harden installer with strict mode

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# Exit immediately if a command exits with a non-zero status
-set -e
+# Exit on errors, unset variables, and pipe failures
+set -euo pipefail
 
 KASPA_LINUX_INSTALL=~/.local/share/kaspa-linux/install
 


### PR DESCRIPTION
## Summary
- use `set -euo pipefail` in `install.sh` to abort on unset vars and pipeline failures

## Testing
- `bash -n install.sh`
- `shellcheck install.sh` *(fails: command not found; package repositories inaccessible)*
- `bash install.sh` *(fails: /root/.local/share/kaspa-linux/install/preflight/aur.sh: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b95da978f8832b9a1c5e8222dafed9