### PR TITLE
feat(comment-it): proxy auth flow through kaspa-auth service

### DIFF
--- a/applications/kdapps/comment-it/README.md
+++ b/applications/kdapps/comment-it/README.md
@@ -22,6 +22,16 @@ Mode B — HTTP organizer peer (full UI)
 - Open: `http://localhost:8080` (wallet flows + auth + comments)
 - CLI helpers: see `src/cli/organizer_commands.rs` and `TESTING.md`
 
+### Authentication Flow
+
+The organizer now proxies authentication requests to a running `kaspa-auth` service.
+Set `KASPA_AUTH_URL` to point at the service (defaults to `http://127.0.0.1:8901`).
+
+1. `POST /auth/start` – create or join an episode via `kaspa-auth`.
+2. `GET /auth/challenge/:id` – issue a challenge using `kaspa-auth`'s `/auth/request-challenge`.
+3. `POST /auth/verify` – verify the signed nonce and receive a session token.
+4. `POST /auth/revoke-session` – revoke a session through `kaspa-auth`.
+
 ## RPC Reliability (dev)
 - Reuses a shared Kaspa RPC client instance.
 - Retry-on-disconnect for `submit_transaction` (treats "already accepted" as success; retries on transient WebSocket errors and orphan cases).

--- a/applications/kdapps/comment-it/src/api/http/types.rs
+++ b/applications/kdapps/comment-it/src/api/http/types.rs
@@ -1,13 +1,13 @@
 // src/api/http/types.rs
 use serde::{Deserialize, Serialize};
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct AuthRequest {
     pub public_key: String,
     pub episode_id: Option<u64>, // For joining existing episodes
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct AuthResponse {
     #[serde(serialize_with = "serialize_u64_as_string")]
     pub episode_id: u64,
@@ -17,7 +17,7 @@ pub struct AuthResponse {
     pub status: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct ChallengeRequest {
     #[serde(deserialize_with = "deserialize_u64_flexible")]
     pub episode_id: u64,
@@ -39,7 +39,7 @@ where
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct ChallengeResponse {
     #[serde(serialize_with = "serialize_u64_as_string")]
     pub episode_id: u64,
@@ -48,14 +48,14 @@ pub struct ChallengeResponse {
     pub status: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct VerifyRequest {
     pub episode_id: u64,
     pub signature: String,
     pub nonce: String,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct VerifyResponse {
     #[serde(serialize_with = "serialize_u64_as_string")]
     pub episode_id: u64,
@@ -72,14 +72,14 @@ pub struct EpisodeStatus {
     pub status: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct RevokeSessionRequest {
     pub episode_id: u64,
     pub session_token: String,
     pub signature: String,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct RevokeSessionResponse {
     #[serde(serialize_with = "serialize_u64_as_string")]
     pub episode_id: u64,


### PR DESCRIPTION
## Summary
- forward auth endpoints to `kaspa-auth` service with proper logging and error handling
- derive serde traits for auth request/response types
- document `KASPA_AUTH_URL` proxy flow in comment-it README

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b960557d44832bb78a699dad2df74a