### PR TITLE
feat(kaspax): secure password storage and verification

### DIFF
--- a/applications/kdapps/kaspa-auth/Cargo.toml
+++ b/applications/kdapps/kaspa-auth/Cargo.toml
@@ -29,6 +29,7 @@ tracing = "0.1"
 tracing-subscriber = "0.3"
 bincode = "1.3"
 keyring = { version = "3.0.0", features = ["windows-native"] }
+argon2 = "0.5"
 
 # Kaspa crypto dependencies
 kaspa-consensus-core = { workspace = true }
@@ -36,3 +37,6 @@ kaspa-hashes = { workspace = true }
 kaspa-addresses = { workspace = true }
 kaspa-wrpc-client = { workspace = true }
 kaspa-rpc-core = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"


### PR DESCRIPTION
## Summary
- hash passwords with Argon2 when creating identities
- verify supplied passwords against stored hashes before unlocking
- test that incorrect passwords are rejected

## Testing
- `cargo test` *(fails: failed to download from crates.io - CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b965bbc588832b9a2e446341ad2da1