### PR TITLE
fix(kaspa-auth): dedupe storage mode flags

### DIFF
--- a/applications/kdapps/kaspa-auth/scripts/set-storage-mode.sh
+++ b/applications/kdapps/kaspa-auth/scripts/set-storage-mode.sh
@@ -63,18 +63,24 @@ WantedBy=default.target
 UNIT
 
 # Normalize any accidental duplicates and mixed modes (belt-and-suspenders)
-sed -i 's/--keychain\s\+--keychain/--keychain/g' "$UNIT_PATH" || true
-sed -i 's/--dev-mode\s\+--dev-mode/--dev-mode/g' "$UNIT_PATH" || true
+sed -E -i 's/--keychain[[:space:]]+--keychain/--keychain/g' "$UNIT_PATH" || true
+sed -E -i 's/--dev-mode[[:space:]]+--dev-mode/--dev-mode/g' "$UNIT_PATH" || true
 if grep -qE 'ExecStart=.*--dev-mode.*--keychain|ExecStart=.*--keychain.*--dev-mode' "$UNIT_PATH"; then
   # Prefer the explicitly selected MODE_FLAG
   case "$mode" in
     dev)
-      sed -i 's/--keychain\s\+//g' "$UNIT_PATH"
+      sed -E -i 's/--keychain[[:space:]]+//g' "$UNIT_PATH"
       ;;
     keychain)
-      sed -i 's/--dev-mode\s\+//g' "$UNIT_PATH"
+      sed -E -i 's/--dev-mode[[:space:]]+//g' "$UNIT_PATH"
       ;;
   esac
+fi
+
+count=$(grep -c -- "$MODE_FLAG" "$UNIT_PATH")
+if [[ "$count" -ne 1 ]]; then
+  echo "[set-storage-mode] Expected exactly one $MODE_FLAG flag in $UNIT_PATH, found $count" >&2
+  exit 1
 fi
 
 echo "[set-storage-mode] Wrote ${UNIT_PATH} (mode=${mode})"


### PR DESCRIPTION
## Summary
- normalize kaspa-auth systemd unit flags using extended regex
- verify generated units contain exactly one storage mode flag

## Testing
- `bash -n applications/kdapps/kaspa-auth/scripts/set-storage-mode.sh`
- `bash -n applications/kdapps/kaspa-auth/scripts/repair-user-unit.sh`
- `PATH="$TMP_BIN:$PATH" HOME="$TMP_HOME" XDG_CONFIG_HOME="$TMP_HOME/.config" XDG_RUNTIME_DIR="$TMP_HOME/run" bash applications/kdapps/kaspa-auth/scripts/set-storage-mode.sh dev`
- `grep -c -- '--dev-mode' "$TMP_HOME/.config/systemd/user/kaspa-auth.service"`
- `PATH="$TMP_BIN:$PATH" HOME="$TMP_HOME" XDG_CONFIG_HOME="$TMP_HOME/.config" XDG_RUNTIME_DIR="$TMP_HOME/run" bash applications/kdapps/kaspa-auth/scripts/set-storage-mode.sh keychain`
- `grep -c -- '--keychain' "$TMP_HOME/.config/systemd/user/kaspa-auth.service"`


------
https://chatgpt.com/codex/tasks/task_e_68bb0a5051ac832b97c486913b0ce614