### PR TITLE
fix(kaspax): clean up stale runtime socket

### DIFF
--- a/applications/kdapps/kaspa-auth/UNIT_TROUBLESHOOTING.md
+++ b/applications/kdapps/kaspa-auth/UNIT_TROUBLESHOOTING.md
@@ -2,6 +2,14 @@
 
 If the user unit crash-loops or `verify-first-login.sh` reports a socket present but the CLI cannot reach the daemon, you may have a stale socket or duplicated storage-mode flags in the unit.
 
+Before restarting the unit, remove any leftover runtime socket:
+
+```
+if [[ -n "${XDG_RUNTIME_DIR:-}" ]]; then
+  rm -f "${XDG_RUNTIME_DIR}/kaspa-auth.sock" || true
+fi
+```
+
 Quick fix:
 
 ```

--- a/applications/kdapps/kaspa-auth/scripts/repair-user-unit.sh
+++ b/applications/kdapps/kaspa-auth/scripts/repair-user-unit.sh
@@ -39,6 +39,9 @@ if grep -q -- '--dev-mode' "$UNIT_PATH"; then
 fi
 
 echo "[repair-user-unit] Repaired unit flags in $UNIT_PATH"
+if [[ -n "${XDG_RUNTIME_DIR:-}" ]]; then
+  rm -f "${XDG_RUNTIME_DIR}/kaspa-auth.sock" || true
+fi
 systemctl --user daemon-reload
 systemctl --user restart kaspa-auth.service || true
 systemctl --user status kaspa-auth.service --no-pager || true


### PR DESCRIPTION
## Summary
- remove stale runtime socket before systemd reload in repair script
- document manual runtime socket cleanup in unit troubleshooting guide

## Testing
- `bash -n applications/kdapps/kaspa-auth/scripts/repair-user-unit.sh`
- `bash applications/kdapps/kaspa-auth/scripts/verify-first-login.sh` *(fails: Binary missing at /root/.cargo/bin/kaspa-auth)*
- `./verify-clean.sh`
- `./verify-active-files.sh`


------
https://chatgpt.com/codex/tasks/task_e_68bb0c67b20c832b8ab628e6d7fac371