### PR TITLE
fix(kaspax): align kaspa-auth service with graphical session

### DIFF
--- a/applications/kdapps/kaspa-auth/INSTALL.md
+++ b/applications/kdapps/kaspa-auth/INSTALL.md
@@ -43,3 +43,4 @@ If the service crash-loops or the socket exists but the CLI cannot connect:
 ## Notes
 - Systemd hardening: `ProtectHome=read-only` with `ReadWritePaths=%h/.local/share %t` allows CLI in `~/.cargo/bin`, data in `~/.local/share`, and the runtime socket under `$XDG_RUNTIME_DIR`.
 - The unit currently runs the daemon in dev or keychain mode depending on the script you use; production should prefer keychain.
+- The service starts after `default.target` and `graphical-session.target` and declares `Wants=graphical-session.target` to align with graphical session startup.

--- a/applications/kdapps/kaspa-auth/scripts/set-storage-mode.sh
+++ b/applications/kdapps/kaspa-auth/scripts/set-storage-mode.sh
@@ -37,7 +37,7 @@ cat >"$UNIT_PATH" <<UNIT
 [Unit]
 Description=Kaspa Auth Daemon (user)
 After=default.target graphical-session.target
-Wants=default.target
+Wants=graphical-session.target
 
 [Service]
 Type=simple

--- a/applications/kdapps/kaspa-auth/systemd/kaspa-auth.service
+++ b/applications/kdapps/kaspa-auth/systemd/kaspa-auth.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Kaspa Auth Daemon (user)
-After=network.target
+After=default.target graphical-session.target
+Wants=graphical-session.target
 
 [Service]
 Type=simple
@@ -10,14 +11,21 @@ ExecStart=%h/.cargo/bin/kaspa-auth --dev-mode daemon start --foreground \
   --socket-path %t/kaspa-auth.sock \
   --data-dir %h/.local/share/kaspa-auth \
   --session-timeout 3600
-Restart=on-failure
+Environment=KASPA_AUTH_DATA_DIR=%h/.local/share/kaspa-auth
+Restart=always
 RestartSec=2s
-NoNewPrivileges=yes
+
+# Hardening
 ProtectSystem=full
-## Allow read-only $HOME but permit writes to data dir and runtime dir
 ProtectHome=read-only
 ReadWritePaths=%h/.local/share %t
+NoNewPrivileges=yes
 PrivateTmp=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+MemoryDenyWriteExecute=yes
+LockPersonality=yes
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
## Summary
- ensure kaspa-auth user service starts after `default.target` and `graphical-session.target`
- sync service hardening and restart behaviour with `set-storage-mode.sh`
- document new graphical session dependencies in INSTALL guide

## Testing
- `./verify-clean.sh`
- `./verify-active-files.sh`
- `bash applications/kdapps/kaspa-auth/scripts/verify-first-login.sh --help` *(fails: Binary missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0f0b8c6c832b93dbbca7fd0522df